### PR TITLE
python upgrade to 3.10, dict.iteritems changed to dict.items

### DIFF
--- a/file_io.py
+++ b/file_io.py
@@ -30,7 +30,7 @@ def write_set_to_txt(output,output_file):
 
 def write_dict_to_txt(output,output_file):
 	with open(output_file,"w") as f:
-		for k,v in output.iteritems():
+		for k,v in output.items():
 			f.write(str(k) + " " + str(v) + " \n")
 
 


### PR DESCRIPTION
python upgrade to 3.10 from 2.7, dict.iteritems changed to dict.items